### PR TITLE
refactor: Use binary of saturn-bot in integration tests

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -18,8 +18,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
+      - uses: actions/setup-go@v4
       - uses: Gr1N/setup-poetry@v9
       - run: poetry install --all-extras
       - run: make lint
       - run: make test
+      - run: go install github.com/wndhydrnt/saturn-bot@main
       - run: make test_integration

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-PROTOCOL_VERSION?=v0.11.2
+PROTOCOL_VERSION?=v0.11.3
 INTEGRATION_TEST_BIN=integration-test-$(PROTOCOL_VERSION).$(shell uname -s)-$(shell uname -m)
 INTEGRATION_TEST_PATH=integration_test/$(INTEGRATION_TEST_BIN)
+SATURN_BOT_BIN_PATH?=saturn-bot
 
 clean:
 	rm saturn_bot/protocol/v1/saturnbot.proto
@@ -46,4 +47,4 @@ $(INTEGRATION_TEST_PATH):
 	chmod +x $(INTEGRATION_TEST_PATH)
 
 test_integration: $(INTEGRATION_TEST_PATH)
-	poetry run $(INTEGRATION_TEST_PATH) -path integration_test/integration_test.py
+	poetry run $(INTEGRATION_TEST_PATH) -plugin-path integration_test/integration_test.py -saturn-bot-path $(SATURN_BOT_BIN_PATH)


### PR DESCRIPTION
Allows easier integration with new releases of saturn-bot.